### PR TITLE
Note limitations in README, limit paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ name: ci
 on:
   pull_request:
     paths:
-      - 'metadata/databases/**.yaml'
-      - 'metadata/version.yaml'
+      - 'metadata/**.yaml'
 jobs:
   hasura-change-summary:
     runs-on: ubuntu-latest
@@ -34,6 +33,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           hasura_endpoint: https://my-pr-${{ github.event.number }}-app.example.com
       - uses: marocchino/sticky-pull-request-comment@v2
+        if: steps.hasura-change.outputs.change_html
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.hasura-change.outputs.change_html }}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 <img src="https://user-images.githubusercontent.com/847532/169708857-5aed1ebb-76c4-43de-8309-469c0e8cf2f2.jpg" alt="Hasura Change Summary example comment" width="689">
 
-The action supports changes to database table mappings (in `metadata/databases/`).
-It does not support [other metadata]([url](https://hasura.io/docs/latest/graphql/core/migrations/reference/metadata-format/#databases)),
-such as Actions, Allow Lists, Cron Triggers, Query Collections, Remote Schemas, or Functions.
+## Features
+
+This action currently supports changes to database table metadata including row-level and column-level permissions.
+
+[Other metadata](https://hasura.io/docs/latest/graphql/core/migrations/reference/metadata-format/) such as actions, cron triggers, and remote schemas are not currently supported.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 <img src="https://user-images.githubusercontent.com/847532/169708857-5aed1ebb-76c4-43de-8309-469c0e8cf2f2.jpg" alt="Hasura Change Summary example comment" width="689">
 
+The action supports changes to database table mappings (in `metadata/databases/`).
+It does not support [other metadata]([url](https://hasura.io/docs/latest/graphql/core/migrations/reference/metadata-format/#databases)),
+such as Actions, Allow Lists, Cron Triggers, Query Collections, Remote Schemas, or Functions.
+
 ## Usage
 
 For example, with marocchino's [Sticky Pull Request Comment](https://github.com/marocchino/sticky-pull-request-comment):
@@ -15,7 +19,8 @@ name: ci
 on:
   pull_request:
     paths:
-      - 'metadata/**.yaml'
+      - 'metadata/databases/**.yaml'
+      - 'metadata/version.yaml'
 jobs:
   hasura-change-summary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Awesome Github Action! We got caught up by missing important metadata changes in large diffs before, and this helps. But: We use a lot more Hasura features than just its database table mappings, and the Github Action doesn't provide change summaries for those. Which is fine, but it also breaks the build because [sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) receives an empty message output from this action.

I'm proposing to limit the watched paths to ones that should reliably produce a message output from the action, and note the current limitations in the README to avoid a false sense of security in users of this action.